### PR TITLE
Throw Exception on Invalid API Responses

### DIFF
--- a/src/RealTag.php
+++ b/src/RealTag.php
@@ -2,9 +2,6 @@
 
 namespace westonwatson\realtag;
 
-use westonwatson\realtag\HttpRequest;
-use westonwatson\realtag\CurlRequest;
-
 /**
  * Class RealTag
  *
@@ -19,6 +16,10 @@ class RealTag
     const REQUIRED_POST_DATA     = ['FullName', 'AddressLine1', 'City', 'State', 'Zip'];
 
     const NON_REQUIRED_POST_DATA = ['ExternalID', 'AddressLine2'];
+
+    const BLANK_RESPONSE_ERROR   = 'Invalid RealTag API Response. This is most likely because of a Bad/Missing Token.';
+
+    const INVALID_RESPONSE_ERROR = 'The RealTag API Responded with Invalid JSON: ';
 
     /**
      * @var string
@@ -154,7 +155,17 @@ class RealTag
      */
     private function decodeResponse($response)
     {
-        return json_decode($response);
+        if (!$response) {
+            throw new \Exception(self::BLANK_RESPONSE_ERROR);
+        }
+
+        $object = json_decode($response);
+
+        if ($object === null) {
+            throw new \Exception(self::INVALID_RESPONSE_ERROR . $response);
+        }
+
+        return $object;
     }
 
     /**

--- a/tests/RealTagTest.php
+++ b/tests/RealTagTest.php
@@ -8,6 +8,7 @@ use westonwatson\realtag\CurlRequest;
 use westonwatson\realtag\HttpRequest;
 use westonwatson\realtag\RealTag;
 use stdClass;
+use westonwatson\realtag\RealTagHelper;
 
 /**
  * Class RealTagTest
@@ -55,16 +56,15 @@ class RealTagTest extends TestCase
 
     public function testDecodeResponseAndSetEndpointAndSetHeaders()
     {
-        $testTokenString = self::TEST_TOKEN;
-        $testBaseUrl     = 'http://google.com';
-        $testEndpoint    = "{$testBaseUrl}?code={$testTokenString}";
-
-        $stub            = $this->createMock(CurlRequest::class);
+        $test_token_string = self::TEST_TOKEN;
+        $testBaseUrl       = 'http://google.com';
+        $test_endpoint     = "{$testBaseUrl}?code={$test_token_string}";
+        $stub              = $this->createMock(CurlRequest::class);
 
         $stub
             ->expects($this->any())
             ->method('setUrl')
-            ->with($testEndpoint);
+            ->with($test_endpoint);
 
         $stub
             ->expects($this->once())
@@ -76,11 +76,34 @@ class RealTagTest extends TestCase
             ->method('execute')
             ->willReturn($this->testResponse);
 
-        $realtag = new RealTag($testTokenString, true, $stub);
+        $realtag = new RealTag($test_token_string, true, $stub);
         $realtag->setEndpoint($testBaseUrl);
 
-        $mockedResponse = $realtag->call(self::GOOD_POST_DATA);
+        $mocked_response = $realtag->call(self::GOOD_POST_DATA);
 
-        $this->assertEquals($this->testDecodedResp, $mockedResponse);
+        $this->assertEquals($this->testDecodedResp, $mocked_response);
+    }
+
+    public function testBlankResponseException()
+    {
+        $test_token_string = self::TEST_TOKEN;
+        $stub              = $this->createMock(CurlRequest::class);
+        $realtag           = new RealTag($test_token_string, true, $stub);
+
+        $stub
+            ->expects($this->any())
+            ->method('execute')
+            ->willReturn('');
+
+        $this->expectException(\Exception::class);
+
+        $realtag->call(self::GOOD_POST_DATA);
+    }
+
+    public function testInvalidInput()
+    {
+        $realtag = new RealTag(self::TEST_TOKEN, true);
+        $this->expectException(\Exception::class);
+        $realtag->call([]);
     }
 }


### PR DESCRIPTION
Throw Exceptions when API Responds with nothing or invalid JSON, plus test coverage for invalid responses and required field validation.